### PR TITLE
Undo feature for highlight markup

### DIFF
--- a/js/content_script.js
+++ b/js/content_script.js
@@ -60,9 +60,18 @@ function makeHighlightSelection() {
     var selection = window.getSelection();
     for (var i = 0; i < selection.rangeCount; i++) {
         var allNodeThatHaveTextInSelectionRange = getTextFromCommonAncestorNode(selection.getRangeAt(i));
-        allNodeThatHaveTextInSelectionRange.forEach(function (range) {
-            doSpan(range);
-        });
+        
+        // If selection contains mark already, undo selection.
+        if ( allNodeThatHaveTextInSelectionRange.getElementsByTagName("MARK").length > 0 );
+        containsMark ) {
+            allNodeThatHaveTextInSelectionRange.forEach(function (range) {
+                undoSpan(range);
+            });
+        } else {
+            allNodeThatHaveTextInSelectionRange.forEach(function (range) {
+                doSpan(range);
+            });
+        }
     }
 }
 
@@ -75,6 +84,11 @@ function doSpan(oldChild) {
     newChild.style.color = "black";
     //newChild.className = "67111";
     newChild.appendChild(oldChild.cloneNode(true));
+    oldChild.parentNode.replaceChild(newChild, oldChild);
+}
+function undoSpan(oldChild) {
+    if ( oldChild.tagName != "MARK" ) return;
+    var newChild = oldChild.firstChild.cloneNode(true);
     oldChild.parentNode.replaceChild(newChild, oldChild);
 }
 


### PR DESCRIPTION
Saw this addon in firefox, there was a comment for undo feature and I agree on that.
Code searches from selection for mark element, if found, will undo the markup span from elements if they are really found there.
I have not tested this as I don't have any experience in firefox addons so it's up to you to check how it works out.